### PR TITLE
fix: lazy Pinia in API client and stabilize PrimeVue Vite setup

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,10 +1,5 @@
-import axios, { type InternalAxiosRequestConfig, type AxiosResponse } from 'axios'
-// import { useToast } from 'primevue/usetoast'
-import { storeToRefs } from 'pinia'
+import axios, { type InternalAxiosRequestConfig } from 'axios'
 import { useToastStore } from '@/stores/modules/toast'
-
-const toastStore = useToastStore()
-const { toastMsg } = storeToRefs(toastStore)
 
 const baseURL: string = 'http://127.0.0.1:3000'
 const service = axios.create({
@@ -31,8 +26,7 @@ service.interceptors.response.use(
   },
   (error) => {
     if (error.response && error.response.status === 401) {
-      // Handle unauthorized error
-      toastMsg.value = 'Unauthorized. Please log in again.'
+      useToastStore().toastMsg = 'Unauthorized. Please log in again.'
     }
     return Promise.reject(error)
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,6 @@ const MyPreset = definePreset(Aura, {
 })
 
 app.use(pinia)
-app.use(router)
 app.use(PrimeVue, {
   theme: {
     preset: MyPreset,
@@ -49,6 +48,7 @@ app.use(PrimeVue, {
 })
 app.use(ToastService)
 app.use(ConfirmationService)
+app.use(router)
 app.use(
   LoadingPlugin
   // {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,7 +39,18 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
-    }
+    },
+    dedupe: ['vue', 'primevue']
+  },
+  optimizeDeps: {
+    include: [
+      'primevue/config',
+      'primevue/useconfirm',
+      'primevue/usetoast',
+      'primevue/confirmationservice',
+      'primevue/toastservice',
+      'primevue/confirmationeventbus'
+    ]
   },
   server: {
     port: 8090,


### PR DESCRIPTION
Load the toast store inside the 401 handler instead of at module scope, register the router after PrimeVue and dialog services, and dedupe/prebundle Vue and PrimeVue for dev resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build dependency optimization for Vue and PrimeVue to improve loading performance.
  * Refined application initialization sequence for improved stability.

* **Refactor**
  * Updated error handling mechanism for better code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sam821203/Pulse-frontend/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->