### PR TITLE
Chore/cursor agent skills

### DIFF
--- a/.cursor/skills/generate-issue-markdown/SKILL.md
+++ b/.cursor/skills/generate-issue-markdown/SKILL.md
@@ -6,20 +6,72 @@ disable-model-invocation: true
 
 # Generate issue markdown
 
-When invoked, output **one** issue in Markdown inside a **single ```markdown** fenced block for one-click copy.
+When invoked, output **one** GitHub-style issue in Markdown inside a **single ```markdown** fenced block for one-click copy.
+
+Issues describe **the problem or need** — not what was implemented. Do **not** mirror [`.github/pull_request_template.md`](.github/pull_request_template.md) (no test plan, checklist, changes list, or branch name).
 
 ## 1. Context
 
 - Branch: `git branch --show-current`.
 - Base: **`develop`** by default (Git Flow); use **`main`** for **`hotfix/*`** or if the user specifies otherwise.
-- Commits: `git log <base>..HEAD --oneline` (+ optional stat).
-- Infer title, description, repro or proposed solution, and acceptance criteria.
+- Commits: `git log <base>..HEAD --oneline` (+ optional `--stat`).
+- From branch name, commit messages, and changed paths, infer **issue type** (`bug` | `feature` | `chore`) and the **problem or motivation** the work addresses. Use commits only to understand scope — write as if filing the issue **before** the work, not as a post-merge summary.
 
-## 2. Structure
+## 2. Structure by type
 
-Include: **Title**, **Description**, **Steps to reproduce** or **Proposed solution**, **Acceptance criteria**, optional **Additional context** (e.g. `Branch: <name>`).
+Use a prefix in the title: `[Bug]`, `[Feature]`, or `[Chore]`.
 
-## 3. Output
+### Bug
+
+- **Description** — what is wrong and user impact (1–3 sentences).
+- **Steps to reproduce** — numbered or bullet list.
+- **Expected behavior** — what should happen.
+- **Actual behavior** — what happens instead.
+
+Do **not** add Acceptance criteria, Test plan, or Additional context unless the user asked for environment details (browser, OS, URL) that are essential to reproduce.
+
+### Feature
+
+- **Description** — problem or user need (1–3 sentences).
+- **Motivation** (optional) — why this matters; one short paragraph or bullets.
+- **Proposed solution** (optional) — high-level approach only if clear from context; avoid implementation detail copied from commits.
+
+Do **not** add Acceptance criteria, Steps to reproduce, or branch/PR metadata.
+
+### Chore / refactor / docs / deps
+
+- **Description** — what should improve and why (1–3 sentences).
+
+No other sections unless the user explicitly requests them.
+
+## 3. Do not include (PR / retroactive noise)
+
+- **Acceptance criteria** — belongs in planning or PR verification, not in issues generated from branch history.
+- **Additional context** with `Branch: …` — branch lives on the PR; link issues via `Fixes #` in the PR, not in the issue body.
+- **Summary of changes**, **Test plan**, **Checklist**, or file-level diffs — those belong in the PR description.
+
+## 4. Output
 
 - Start the assistant reply with the fenced block (minimal preamble).
 - Clear, concise English.
+- One `##` heading per section; omit empty sections.
+
+Example (bug):
+
+```markdown
+## [Bug] Stock detail header shows stale price after refresh
+
+## Description
+After a hard refresh on the company detail page, the header still shows the previous session's last price until the user navigates away.
+
+## Steps to reproduce
+1. Open a listed company detail page and note the price in the header.
+2. Hard refresh the browser (Cmd+Shift+R).
+3. Observe the header price.
+
+## Expected behavior
+The header shows the current price (or a loading state) immediately after refresh.
+
+## Actual behavior
+The header shows a stale price from the prior visit.
+```

--- a/.cursor/skills/generate-issue-markdown/SKILL.md
+++ b/.cursor/skills/generate-issue-markdown/SKILL.md
@@ -21,26 +21,28 @@ Issues describe **the problem or need** — not what was implemented. Do **not**
 
 Use a prefix in the title: `[Bug]`, `[Feature]`, or `[Chore]`.
 
+**Writing style:** Under each `##` section, use **bullet lists** (`-`), not paragraphs. Prefer 2–5 short bullets per section; one idea per bullet. Omit empty sections.
+
 ### Bug
 
-- **Description** — what is wrong and user impact (1–3 sentences).
-- **Steps to reproduce** — numbered or bullet list.
-- **Expected behavior** — what should happen.
-- **Actual behavior** — what happens instead.
+- **Description** — what is wrong and user impact (bullets).
+- **Steps to reproduce** — bullet list in order.
+- **Expected behavior** — what should happen (bullets).
+- **Actual behavior** — what happens instead (bullets).
 
 Do **not** add Acceptance criteria, Test plan, or Additional context unless the user asked for environment details (browser, OS, URL) that are essential to reproduce.
 
 ### Feature
 
-- **Description** — problem or user need (1–3 sentences).
-- **Motivation** (optional) — why this matters; one short paragraph or bullets.
-- **Proposed solution** (optional) — high-level approach only if clear from context; avoid implementation detail copied from commits.
+- **Description** — problem or user need (bullets).
+- **Motivation** (optional) — why this matters (bullets).
+- **Proposed solution** (optional) — high-level approach only if clear from context (bullets); avoid implementation detail copied from commits.
 
 Do **not** add Acceptance criteria, Steps to reproduce, or branch/PR metadata.
 
 ### Chore / refactor / docs / deps
 
-- **Description** — what should improve and why (1–3 sentences).
+- **Description** — what should improve and why (bullets).
 
 No other sections unless the user explicitly requests them.
 
@@ -54,7 +56,7 @@ No other sections unless the user explicitly requests them.
 
 - Start the assistant reply with the fenced block (minimal preamble).
 - Clear, concise English.
-- One `##` heading per section; omit empty sections.
+- One `##` heading per section; body content is always bullet lists under each heading.
 
 Example (bug):
 
@@ -62,16 +64,17 @@ Example (bug):
 ## [Bug] Stock detail header shows stale price after refresh
 
 ## Description
-After a hard refresh on the company detail page, the header still shows the previous session's last price until the user navigates away.
+- After a hard refresh on the company detail page, the header still shows the previous session's last price.
+- Users cannot trust the displayed price until they navigate away.
 
 ## Steps to reproduce
-1. Open a listed company detail page and note the price in the header.
-2. Hard refresh the browser (Cmd+Shift+R).
-3. Observe the header price.
+- Open a listed company detail page and note the price in the header.
+- Hard refresh the browser (Cmd+Shift+R).
+- Observe the header price.
 
 ## Expected behavior
-The header shows the current price (or a loading state) immediately after refresh.
+- The header shows the current price or a loading state immediately after refresh.
 
 ## Actual behavior
-The header shows a stale price from the prior visit.
+- The header shows a stale price from the prior visit.
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ coverage
 /cypress/videos/
 /cypress/screenshots/
 
+# Cursor agent skills (installed locally; see skills-lock.json)
+.agents/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/README.md
+++ b/README.md
@@ -24,6 +24,33 @@ A real-time stock tracking and analysis platform built with Vue3. It provides re
 npm install
 ```
 
+### Cursor agent skills (optional)
+
+This repo tracks **project-specific** Cursor rules under `.cursor/` (committed). **Agent skills** from the open ecosystem are listed in `skills-lock.json` but installed under `.agents/skills/`, which is gitignored.
+
+After cloning on a new machine, install the locked skills into the project (requires [Node.js](https://nodejs.org/) for `npx`):
+
+```sh
+npx skills add sickn33/antigravity-awesome-skills --skill claude-d3js-skill -a cursor -y
+npx skills add harlan-zw/vue-ecosystem-skills --skill primevue-skilld -a cursor -y
+npx skills add hairyf/skills --skill tailwindcss -a cursor -y
+npx skills add wshobson/agents --skill typescript-advanced-types -a cursor -y
+npx skills add github/awesome-copilot --skill unit-test-vue-pinia -a cursor -y
+npx skills add antfu/skills --skill vue --skill vite --skill vitest -a cursor -y
+npx skills add hyf0/vue-skills --skill vue-best-practices --skill vue-debug-guides --skill vue-pinia-best-practices -a cursor -y
+npx skills add teachingai/full-stack-skills --skill vue-router-v4 -a cursor -y
+```
+
+Verify installation:
+
+```sh
+npx skills list -a cursor
+```
+
+Restart Cursor or open a new Agent chat so skills are discovered. To update installed skills later: `npx skills update -a cursor -y`.
+
+> **Note:** Some upstream skills target newer tool versions (e.g. Tailwind v4, Vitest 3) than this project’s `package.json`. Treat `package.json` as the source of truth for runtime versions.
+
 ### Compile and Hot-Reload for Development
 
 ```sh

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "skills": {
+    "claude-d3js-skill": {
+      "source": "sickn33/antigravity-awesome-skills",
+      "sourceType": "github",
+      "skillPath": "skills/claude-d3js-skill/SKILL.md",
+      "computedHash": "45535337456473af6178cebde498dd8bb255ea65fd41db7baa3e851e6947778f"
+    },
+    "primevue-skilld": {
+      "source": "harlan-zw/vue-ecosystem-skills",
+      "sourceType": "github",
+      "skillPath": "skills/primevue-skilld/SKILL.md",
+      "computedHash": "197d0e40b161b75674ab0cb02cc805ca2ab467b22d769780b819f1df62354abd"
+    },
+    "tailwindcss": {
+      "source": "hairyf/skills",
+      "sourceType": "github",
+      "skillPath": "skills/tailwindcss/SKILL.md",
+      "computedHash": "676d95536c3c4a64215535ff09128d6e8d5163eb3fc204ed2cfde61e87b5d892"
+    },
+    "typescript-advanced-types": {
+      "source": "wshobson/agents",
+      "sourceType": "github",
+      "skillPath": "plugins/javascript-typescript/skills/typescript-advanced-types/SKILL.md",
+      "computedHash": "3a3be8c925f96ac4e1280db28a01677e7ca5197f3792de2bbf35ab3bb324b6dd"
+    },
+    "unit-test-vue-pinia": {
+      "source": "github/awesome-copilot",
+      "sourceType": "github",
+      "skillPath": "skills/unit-test-vue-pinia/SKILL.md",
+      "computedHash": "ef6e0d48f9932bcfb6220f2790fb5cfc3c1e84b17e04e9ec219331489b47a66f"
+    },
+    "vite": {
+      "source": "antfu/skills",
+      "sourceType": "github",
+      "skillPath": "skills/vite/SKILL.md",
+      "computedHash": "867ff66238f3152e9c494339ad08dc432dd0df5bcf5cc7a00b61a72b580eb908"
+    },
+    "vitest": {
+      "source": "antfu/skills",
+      "sourceType": "github",
+      "skillPath": "skills/vitest/SKILL.md",
+      "computedHash": "669c7275f7e1379b06b2bcfa593603aead4c983b951c7e8edbc09640aa38d0a1"
+    },
+    "vue": {
+      "source": "antfu/skills",
+      "sourceType": "github",
+      "skillPath": "skills/vue/SKILL.md",
+      "computedHash": "9c241141e07e836e4f0537c63e8f929fba3767c2997250be38e699f19b75e3f2"
+    },
+    "vue-best-practices": {
+      "source": "hyf0/vue-skills",
+      "sourceType": "github",
+      "skillPath": "skills/vue-best-practices/SKILL.md",
+      "computedHash": "3df585ad31aec78fe55c56c1411262737e6b231677a3153dec512a882fde80cd"
+    },
+    "vue-debug-guides": {
+      "source": "hyf0/vue-skills",
+      "sourceType": "github",
+      "skillPath": "skills/vue-debug-guides/SKILL.md",
+      "computedHash": "fa7b31c32a6717ae47cd2ea208773e27536225ad053a564effe656bf927fe9ef"
+    },
+    "vue-pinia-best-practices": {
+      "source": "hyf0/vue-skills",
+      "sourceType": "github",
+      "skillPath": "skills/vue-pinia-best-practices/SKILL.md",
+      "computedHash": "d4ba913bec21910b8e37b2115cd964df2dc43ad62346b981c7b88d4ddc8cf792"
+    },
+    "vue-router-v4": {
+      "source": "teachingai/full-stack-skills",
+      "sourceType": "github",
+      "skillPath": "skills/vue-skills/vue-router-v4/SKILL.md",
+      "computedHash": "f7ff3734d237d3eecd56f6c8f5d159167a642430f8a68f204c8136ba3a5741db"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Cursor agent skills from the open ecosystem were not pinned or documented, so teammates could not reliably reproduce the same Agent setup after cloning.
- Added `skills-lock.json` and README install steps for locked skills under `.agents/skills/` (gitignored), and refined the `generate-issue-markdown` skill for clearer, type-specific issue output.

## Changes

- Add `skills-lock.json` listing pinned ecosystem skills (Vue, Vite, Vitest, PrimeVue, Tailwind, D3, testing, router, etc.) with source repos and hashes
- Gitignore `.agents/skills/` so installed skill copies stay local while the lockfile is committed
- Document optional Cursor agent skills setup and verification in `README.md` (`npx skills add` / `npx skills list`)
- Refine `.cursor/skills/generate-issue-markdown/SKILL.md` with issue-type-specific guidance
- Require bullet lists in generated issue markdown within the same skill

## Scope

Pick one (matches commit scopes in `.cursor/rules/commit-message.mdc`):

- [ ] ui
- [ ] page
- [ ] component
- [ ] composable
- [ ] api
- [ ] store
- [ ] router
- [ ] auth
- [ ] theme
- [ ] build
- [ ] test
- [x] docs
- [ ] devops
- [ ] deps

## Related

- Fixes #9 
- Follow-ups:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for installing and configuring Cursor agent skills with verification commands.

* **Chores**
  * Updated version control configuration to exclude locally installed agent skills.
  * Introduced skill version tracking with a new lockfile.
  * Enhanced Cursor skill prompts for stricter issue formatting standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sam821203/Pulse-frontend/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->